### PR TITLE
FIx: rename threshold to similarity in SearchParams type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,7 @@ export type SearchParams = {
   datasourceIDs?: string[]
   boost?: { [key: string]: number }
   exact?: boolean
+  threshold?: number
   similarity?: number
   tolerance?: number
   userID?: string


### PR DESCRIPTION
This pull request makes a minor change to the search parameters type definition. The `threshold` field in the `SearchParams` type has been renamed to `similarity` to reflect the renamed made to OramaCore.