### PR TITLE
feat: regenerate api key

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -8,6 +8,7 @@ import type {
   Nullable,
   PinningRule,
   PinningRuleInsertObject,
+  RegenerateReadAPIKeyResponse,
   SearchParams,
   SearchResult,
   TrainingSetInsertParameters,
@@ -389,6 +390,16 @@ class CollectionsNamespace {
       init,
       apiKeyPosition: 'query-params',
       target: 'reader',
+    })
+  }
+
+  public regenerateReadAPIKey(init?: ClientRequestInit): Promise<RegenerateReadAPIKeyResponse> {
+    return this.client.request<RegenerateReadAPIKeyResponse>({
+      path: `/v1/collections/${this.collectionID}/regenerate-read-api-key`,
+      method: 'POST',
+      init,
+      apiKeyPosition: 'header',
+      target: 'writer',
     })
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -380,6 +380,10 @@ export type IndexesStats = {
   }
 }
 
+export type RegenerateReadAPIKeyResponse = {
+  read_api_key: string
+}
+
 export type CollectionStats = {
   created_at: string
   default_locale: string


### PR DESCRIPTION
This pull request introduces a new API endpoint for regenerating a collection's read API key and adds the corresponding type definition. The main changes are focused on expanding the collection management functionality.

New API support for read API key regeneration:

* Added the `regenerateReadAPIKey` method to the `CollectionsNamespace` class in `src/collection.ts`, enabling clients to regenerate a collection's read API key via a POST request.
* Introduced the `RegenerateReadAPIKeyResponse` type in `src/lib/types.ts` to represent the response structure for the new API endpoint.
* Updated the import statements in `src/collection.ts` to include the new `RegenerateReadAPIKeyResponse` type.